### PR TITLE
Bump spring-boot.version from 3.1.5 to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <!-- Run Docker build by default -->
     <skipDocker>false</skipDocker>
     <sortpom-maven-plugin.version>3.3.0</sortpom-maven-plugin.version>
-    <spring-boot.version>3.1.5</spring-boot.version>
+    <spring-boot.version>3.2.0</spring-boot.version>
     <testcontainers.version>1.19.1</testcontainers.version>
     <testng.version>7.8.0</testng.version>
     <xmlunit-assertj3.version>2.9.1</xmlunit-assertj3.version>


### PR DESCRIPTION
Bumps `spring-boot.version` from 3.1.5 to 3.2.0.

Updates `org.springframework.boot:spring-boot-starter-parent` from 3.1.5 to 3.2.0
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v3.1.5...v3.2.0)

Updates `org.springframework.boot:spring-boot-maven-plugin` from 3.1.5 to 3.2.0
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v3.1.5...v3.2.0)

---
updated-dependencies:
- dependency-name: org.springframework.boot:spring-boot-starter-parent dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.springframework.boot:spring-boot-maven-plugin dependency-type: direct:production update-type: version-update:semver-minor ...

## Description
<!--- Describe your changes -->

## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.
