### PR TITLE
Bump kotlin.version from 1.9.20 to 1.9.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <java.version>17</java.version>
     <junit-jupiter.version>5.7.2</junit-jupiter.version>
     <junit.version>4.13.2</junit.version>
-    <kotlin.version>1.9.20</kotlin.version>
+    <kotlin.version>1.9.21</kotlin.version>
     <license-maven-plugin-git.version>4.3</license-maven-plugin-git.version>
     <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>


### PR DESCRIPTION
Bumps `kotlin.version` from 1.9.20 to 1.9.21.

Updates `org.jetbrains.kotlin:kotlin-stdlib-jdk8` from 1.9.20 to 1.9.21
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v1.9.20...v1.9.21)

Updates `org.jetbrains.kotlin:kotlin-test` from 1.9.20 to 1.9.21
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v1.9.20...v1.9.21)

Updates `org.jetbrains.kotlin:kotlin-test-junit` from 1.9.20 to 1.9.21
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v1.9.20...v1.9.21)

Updates `org.jetbrains.kotlin:kotlin-maven-plugin` from 1.9.20 to 1.9.21

---
updated-dependencies:
- dependency-name: org.jetbrains.kotlin:kotlin-stdlib-jdk8 dependency-type: direct:development update-type: version-update:semver-patch
- dependency-name: org.jetbrains.kotlin:kotlin-test dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.jetbrains.kotlin:kotlin-test-junit dependency-type: direct:development update-type: version-update:semver-patch
- dependency-name: org.jetbrains.kotlin:kotlin-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch ...

## Description
<!--- Describe your changes -->

## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.
